### PR TITLE
libusbgx: examples: gadget-vid-pid-remove: fix exit code on success

### DIFF
--- a/examples/gadget-vid-pid-remove.c
+++ b/examples/gadget-vid-pid-remove.c
@@ -116,6 +116,8 @@ int main(int argc, char **argv)
 		}
 	}
 
+	ret = 0;
+
 out2:
 	usbg_cleanup(s);
 out1:


### PR DESCRIPTION
The gadget-vid-pid-remove tool always returns -EINVAL, since ret is
initialized as -EINVAL and never set to 0.

Set ret to 0 on the success exit path to signal that a gadget was
successfully removed.