### PR TITLE
Dev/net improve attributes to use Windows 10 native RNDIS driver

### DIFF
--- a/include/usbg/function/net.h
+++ b/include/usbg/function/net.h
@@ -29,6 +29,9 @@ struct usbg_f_net_attrs {
 	struct ether_addr host_addr;
 	const char *ifname;
 	int qmult;
+	unsigned int class;
+	unsigned int subclass;
+	unsigned int protocol;
 };
 
 enum usbg_f_net_attr {
@@ -37,6 +40,9 @@ enum usbg_f_net_attr {
 	USBG_F_NET_HOST_ADDR,
 	USBG_F_NET_IFNAME,
 	USBG_F_NET_QMULT,
+	USBG_F_NET_CLASS,
+	USBG_F_NET_SUBCLASS,
+	USBG_F_NET_PROTOCOL,
 	USBG_F_NET_ATTR_MAX
 };
 
@@ -45,6 +51,9 @@ union usbg_f_net_attr_val {
 	struct ether_addr host_addr;
 	const char *ifname;
 	int qmult;
+	unsigned int class;
+	unsigned int subclass;
+	unsigned int protocol;
 };
 
 #define USBG_F_NET_ETHER_ADDR_TO_ATTR_VAL(WHAT)		\
@@ -219,6 +228,78 @@ static inline int usbg_f_net_set_qmult(usbg_f_net *nf, int qmult)
 {
 	return usbg_f_net_set_attr_val(nf, USBG_F_NET_QMULT,
 				       USBG_F_NET_INT_TO_ATTR_VAL(qmult));
+}
+
+/**
+ * @brief Get the value of usb function class
+ * @param[in] nf Pointer to net function
+ * @param[out] class Current class identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_get_class(usbg_f_net *nf, unsigned int *class)
+{
+	return usbg_f_net_get_attr_val(nf, USBG_F_NET_CLASS,
+				       (union usbg_f_net_attr_val *)class);
+}
+
+/**
+ * @brief Set the value of usb function class
+ * @param[in] nf Pointer to net function
+ * @param[in] class Class identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_set_class(usbg_f_net *nf, unsigned int class)
+{
+	return usbg_f_net_set_attr_val(nf, USBG_F_NET_CLASS,
+				       USBG_F_NET_INT_TO_ATTR_VAL(class));
+}
+
+/**
+ * @brief Get the value of usb function subclass
+ * @param[in] nf Pointer to net function
+ * @param[out] subclass Current subclass identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_get_subclass(usbg_f_net *nf, int *subclass)
+{
+	return usbg_f_net_get_attr_val(nf, USBG_F_NET_SUBCLASS,
+				       (union usbg_f_net_attr_val *)subclass);
+}
+
+/**
+ * @brief Set the value of usb function subclass
+ * @param[in] nf Pointer to net function
+ * @param[in] subclass Subclass identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_set_subclass(usbg_f_net *nf, unsigned int subclass)
+{
+	return usbg_f_net_set_attr_val(nf, USBG_F_NET_SUBCLASS,
+				       USBG_F_NET_INT_TO_ATTR_VAL(subclass));
+}
+
+/**
+ * @brief Get the value of usb function protocol
+ * @param[in] nf Pointer to net function
+ * @param[out] protocol Current protocol identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_get_protocol(usbg_f_net *nf, int *protocol)
+{
+	return usbg_f_net_get_attr_val(nf, USBG_F_NET_PROTOCOL,
+				       (union usbg_f_net_attr_val *)protocol);
+}
+
+/**
+ * @brief Set the value of usb function protocol
+ * @param[in] nf Pointer to net function
+ * @param[in] protocol protocol identification
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_set_protocol(usbg_f_net *nf, unsigned int protocol)
+{
+	return usbg_f_net_set_attr_val(nf, USBG_F_NET_PROTOCOL,
+				       USBG_F_NET_INT_TO_ATTR_VAL(protocol));
 }
 
 #ifdef __cplusplus

--- a/src/function/ether.c
+++ b/src/function/ether.c
@@ -67,6 +67,9 @@ static struct {
 	[USBG_F_NET_HOST_ADDR] = NET_ETHER_ADDR_ATTR(host_addr),
 	[USBG_F_NET_IFNAME] = NET_RO_STRING_ATTR(ifname),
 	[USBG_F_NET_QMULT] = NET_DEC_ATTR(qmult),
+	[USBG_F_NET_CLASS] = NET_DEC_ATTR(class),
+	[USBG_F_NET_SUBCLASS] = NET_DEC_ATTR(subclass),
+	[USBG_F_NET_PROTOCOL] = NET_DEC_ATTR(protocol)
 };
 
 #undef NET_DEC_ATTR

--- a/tests/usbg-test.c
+++ b/tests/usbg-test.c
@@ -1067,6 +1067,18 @@ static void push_net_attrs(struct test_function *func,
 	safe_asprintf(&path, "%s/%s/qmult", func->path, func->name);
 	safe_asprintf(&content, "%d\n", attrs->qmult);
 	PUSH_FILE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/class", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->class);
+	PUSH_FILE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/subclass", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->subclass);
+	PUSH_FILE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/protocol", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->protocol);
+	PUSH_FILE_STR(path, content);
 }
 
 static void push_phonet_attrs(struct test_function *func,
@@ -1127,6 +1139,18 @@ static void pull_function_net_attrs(struct test_function *func,
 
 	safe_asprintf(&path, "%s/%s/qmult", func->path, func->name);
 	safe_asprintf(&content, "%d\n", attrs->qmult);
+	EXPECT_WRITE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/class", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->class);
+	EXPECT_WRITE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/subclass", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->subclass);
+	EXPECT_WRITE_STR(path, content);
+
+	safe_asprintf(&path, "%s/%s/protocol", func->path, func->name);
+	safe_asprintf(&content, "%d\n", attrs->protocol);
 	EXPECT_WRITE_STR(path, content);
 }
 
@@ -1317,6 +1341,9 @@ void assert_f_net_attrs_equal(struct usbg_f_net_attrs *actual,
 	assert_ether_addrs_equal(&actual->host_addr, &expected->host_addr);
 	assert_string_equal(actual->ifname, expected->ifname);
 	assert_int_equal(actual->qmult, expected->qmult);
+	assert_int_equal(actual->class, expected->class);
+	assert_int_equal(actual->subclass, expected->subclass);
+	assert_int_equal(actual->protocol, expected->protocol);
 }
 
 void assert_f_phonet_attrs_equal(char  **actual, char **expected)


### PR DESCRIPTION
This pull request contains an improvement which allows the user to write any value to class, subclass and protocol attributes of net function.

Specifically for RNDIS usage with Windos 10 native driver, the values are: EF (Miscellaneous), 04 (RNDIS) and 01 (RNDIS over Ethernet).