### PR TITLE
MIDI correct integer attribute import / export

### DIFF
--- a/src/function/midi.c
+++ b/src/function/midi.c
@@ -29,8 +29,8 @@ struct usbg_f_midi {
 		.offset = offsetof(struct usbg_f_midi_attrs, _name),    \
 		.get = usbg_get_dec,				        \
 		.set = usbg_set_dec,				        \
-		.import = usbg_get_config_node_string,	                \
-		.export = usbg_set_config_node_string,		        \
+		.import = usbg_get_config_node_int,	                \
+		.export = usbg_set_config_node_int,		        \
 	}
 
 #define MIDI_STRING_ATTR(_name)						\


### PR DESCRIPTION
The attribute import / export functions for MIDI_DEC_ATTR attributes was using the string get / set functions instead of the integer functions.