### PR TITLE
Fix: Memory leak config label

### DIFF
--- a/src/usbg.c
+++ b/src/usbg.c
@@ -751,8 +751,7 @@ static int usbg_parse_config(const char *path, const char *name,
 		goto free_config;
 
 	TAILQ_INSERT_TAIL(&g->configs, c, cnode);
-
-	return USBG_SUCCESS;
+	goto out;
 
 free_config:
 	usbg_free_config(c);


### PR DESCRIPTION
Noticed a minor memory leak of the config label, detected when a second gadget was created.

```
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   fun:strndup
   fun:usbg_split_config_label_id
   fun:usbg_parse_config
   fun:usbg_parse_configs
   fun:usbg_parse_gadget
   fun:usbg_parse_gadgets
   fun:usbg_parse_state
   fun:usbg_init
   fun:create_usbg
   fun:main
}
```