### PR TITLE
load libcomposite kernel module

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,7 @@ the examples are licensed under the GNU GPL-2.0 (or later).
 To run the examples:
 
 $ modprobe configfs
+$ modprobe libcomposite
 $ mount -t configfs none /sys/kernel/config
 $ gadget-acm-ecm
 $ show-gadgets


### PR DESCRIPTION
just a small change, on Fedora 38 this took me a while to figure out.
so adding it here in case anyone else has the following error:
`Error: USBG_ERROR_NOT_FOUND : Not found (file or directory removed)`