### PR TITLE
uac2: add additional configuration controls

### DIFF
--- a/include/usbg/function/uac2.h
+++ b/include/usbg/function/uac2.h
@@ -31,6 +31,26 @@ struct usbg_f_uac2_attrs {
 	int p_chmask;
 	int p_srate;
 	int p_ssize;
+	unsigned char p_hs_bint;
+	unsigned char c_hs_bint;
+
+	const char * c_sync;
+	unsigned int req_number;
+	unsigned int fb_max;
+
+	bool p_mute_present;
+	bool p_volume_present;
+	short p_volume_min;
+	short p_volume_max;
+	short p_volume_res;
+
+	bool c_mute_present;
+	bool c_volume_present;
+	short c_volume_min;
+	short c_volume_max;
+	short c_volume_res;
+
+	const char *function_name;
 };
 
 enum usbg_f_uac2_attr {
@@ -41,6 +61,22 @@ enum usbg_f_uac2_attr {
 	USBG_F_UAC2_P_CHMASK,
 	USBG_F_UAC2_P_SRATE,
 	USBG_F_UAC2_P_SSIZE,
+	USBG_F_UAC2_P_HS_BINT,
+	USBG_F_UAC2_C_HS_BINT,
+	USBG_F_UAC2_C_SYNC,
+	USBG_F_UAC2_REQ_NUMBER,
+	USBG_F_UAC2_FB_MAX,
+	USBG_F_UAC2_P_MUTE_PRESENT,
+	USBG_F_UAC2_P_VOLUME_PRESENT,
+	USBG_F_UAC2_P_VOLUME_MIN,
+	USBG_F_UAC2_P_VOLUME_MAX,
+	USBG_F_UAC2_P_VOLUME_RES,
+	USBG_F_UAC2_C_MUTE_PRESENT,
+	USBG_F_UAC2_C_VOLUME_PRESENT,
+	USBG_F_UAC2_C_VOLUME_MIN,
+	USBG_F_UAC2_C_VOLUME_MAX,
+	USBG_F_UAC2_C_VOLUME_RES,
+	USBG_F_UAC2_FUNCTION_NAME,
 	USBG_F_UAC2_ATTR_MAX
 };
 
@@ -51,6 +87,27 @@ union usbg_f_uac2_attr_val {
 	int p_chmask;
 	int p_srate;
 	int p_ssize;
+
+	char p_hs_bint;
+	char c_hs_bint;
+
+	const char * c_sync;
+	unsigned int req_number;
+	unsigned int fb_max;
+
+	bool p_mute_present;
+	bool p_volume_present;
+	int p_volume_min;
+	int p_volume_max;
+	int p_volume_res;
+
+	bool c_mute_present;
+	bool c_volume_present;
+	int c_volume_min;
+	int c_volume_max;
+	int c_volume_res;
+
+	const char * function_name;
 };
 
 #define USBG_F_UAC2_INT_TO_ATTR_VAL(WHAT)			\

--- a/src/function/uac2.c
+++ b/src/function/uac2.c
@@ -23,6 +23,26 @@ struct usbg_f_uac2 {
 	struct usbg_function func;
 };
 
+#define UAC2_BOOL_ATTR(_name)						\
+	{								\
+		.name = #_name,						\
+		.offset = offsetof(struct usbg_f_uac2_attrs, _name),    \
+		.get = usbg_get_bool,				        \
+		.set = usbg_set_bool,				        \
+		.import = usbg_get_config_node_bool,	                \
+		.export = usbg_set_config_node_bool,		        \
+	}
+
+#define UAC2_STRING_ATTR(_name)					\
+	{								\
+		.name = #_name,						\
+		.offset = offsetof(struct usbg_f_uac2_attrs, _name),     \
+		.get = usbg_get_string,				        \
+		.set = usbg_set_string,				        \
+		.export = usbg_set_config_node_string,		        \
+		.import = usbg_get_config_node_string,	                \
+	}
+
 #define UAC2_DEC_ATTR(_name)						\
 	{								\
 		.name = #_name,						\
@@ -47,6 +67,22 @@ static struct {
 	[USBG_F_UAC2_P_CHMASK] = UAC2_DEC_ATTR(p_chmask),
 	[USBG_F_UAC2_P_SRATE] = UAC2_DEC_ATTR(p_srate),
 	[USBG_F_UAC2_P_SSIZE] = UAC2_DEC_ATTR(p_ssize),
+	[USBG_F_UAC2_P_HS_BINT] = UAC2_DEC_ATTR(p_hs_bint),
+	[USBG_F_UAC2_C_HS_BINT] = UAC2_DEC_ATTR(c_hs_bint),
+	[USBG_F_UAC2_C_SYNC] = UAC2_STRING_ATTR(c_sync),
+	[USBG_F_UAC2_REQ_NUMBER] = UAC2_DEC_ATTR(req_number),
+	[USBG_F_UAC2_FB_MAX] = UAC2_DEC_ATTR(fb_max),
+	[USBG_F_UAC2_P_MUTE_PRESENT] = UAC2_BOOL_ATTR(p_mute_present),
+	[USBG_F_UAC2_P_VOLUME_PRESENT] = UAC2_BOOL_ATTR(p_volume_present),
+	[USBG_F_UAC2_P_VOLUME_MIN] = UAC2_DEC_ATTR(p_volume_min),
+	[USBG_F_UAC2_P_VOLUME_MAX] = UAC2_DEC_ATTR(p_volume_max),
+	[USBG_F_UAC2_P_VOLUME_RES] = UAC2_DEC_ATTR(p_volume_res),
+	[USBG_F_UAC2_C_MUTE_PRESENT] = UAC2_BOOL_ATTR(c_mute_present),
+	[USBG_F_UAC2_C_VOLUME_PRESENT] = UAC2_BOOL_ATTR(c_volume_present),
+	[USBG_F_UAC2_C_VOLUME_MIN] = UAC2_DEC_ATTR(c_volume_min),
+	[USBG_F_UAC2_C_VOLUME_MAX] = UAC2_DEC_ATTR(c_volume_max),
+	[USBG_F_UAC2_C_VOLUME_RES] = UAC2_DEC_ATTR(c_volume_res),
+	[USBG_F_UAC2_FUNCTION_NAME] = UAC2_STRING_ATTR(function_name),
 };
 
 #undef UAC2_DEC_ATTR


### PR DESCRIPTION
This patch adds the possibility to set additional configuration parameters in configfs for uac2.

It adds the controls:

{c,p}_volume_present		capture/playback volume control enable {c,p}_mute_present		capture/playback mute control enable {c,p}_volume_min		capture/playback volume control min value (in 1/256 dB) {c,p}_volume_max		capture/playback volume control max value (in 1/256 dB) {c,p}_volume_res		capture/playback volume control resolution (in 1/256 dB) {c,p}_hs_bint			capture/playback bInterval for HS/SS (1-4: fixed, 0: auto) c_sync				capture synchronization type (async/adaptive) req_number			the number of pre-allocated requests for both capture and playback fb_max				maximum extra bandwidth in async mode

(from kernel:Documentation/ABI/testing/configfs-usb-gadget-uac2)