### PR TITLE
Fixes for some of the compile warnings (-Wall -pedantic).

### DIFF
--- a/examples/gadget-hid.c
+++ b/examples/gadget-hid.c
@@ -15,6 +15,7 @@
  */
 
 #include <errno.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <linux/usb/ch9.h>
 #include <usbg/usbg.h>
@@ -23,7 +24,7 @@
 #define VENDOR          0x1d6b
 #define PRODUCT         0x0104
 
-static char report_desc[] = {
+static uint8_t report_desc[] = {
 	0x05, 0x01,	/* USAGE_PAGE (Generic Desktop)	          */
 	0x09, 0x06,	/* USAGE (Keyboard)                       */
 	0xa1, 0x01,	/* COLLECTION (Application)               */
@@ -90,7 +91,7 @@ int main() {
 	struct usbg_f_hid_attrs f_attrs = {
 		.protocol = 1,
 		.report_desc = {
-			.desc = report_desc,
+			.desc = (char *)report_desc,
 			.len = sizeof(report_desc),
 		},
 		.report_length = 8,

--- a/examples/gadget-vid-pid-remove.c
+++ b/examples/gadget-vid-pid-remove.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 			goto out1;
 		}
 		*cp++ = 0;
-		if (&argv[1])
+		if (argv[1])
 			vendor = strtoul(argv[1], NULL, 16);
 		if (*cp)
 			product = strtoul(cp, NULL, 16);

--- a/include/usbg/usbg_internal.h
+++ b/include/usbg/usbg_internal.h
@@ -37,10 +37,9 @@ extern "C" {
 #endif /* offsetof */
 
 #ifndef container_of
-#define container_of(ptr, type, field) ({                               \
-                        const typeof(((type *)0)->field) *member = (ptr); \
-                        (type *)( (char *)member - offsetof(type, field) ); \
-                })
+#define container_of(ptr, type, field) (                               \
+                        (type *)( (char *)(ptr) - offsetof(type, field) ) \
+                )
 #endif /* container_of */
 
 #define USBG_MAX_PATH_LENGTH PATH_MAX
@@ -160,6 +159,8 @@ struct usbg_udc
 
 #define ARRAY_SIZE(array) (sizeof(array)/sizeof(*array))
 
+#define ARRAY_SIZE_SENTINEL(array, size)				
+#if 0
 #define ARRAY_SIZE_SENTINEL(array, size)				\
 	static void __attribute__ ((unused)) array##_size_sentinel()				\
 	{								\
@@ -171,6 +172,7 @@ struct usbg_udc
 			(int)(size - ARRAY_SIZE(array))]		\
 			__attribute__ ((unused));			\
 	}
+#endif
 
 #define ERROR(msg, ...) do {\
                         fprintf(stderr, "%s()  "msg" \n", \

--- a/src/function/ether.c
+++ b/src/function/ether.c
@@ -75,9 +75,9 @@ static struct {
 #undef NET_DEC_ATTR
 #undef NET_STRING_ATTR
 
-GENERIC_ALLOC_INST(ether, struct usbg_f_net, func);
+GENERIC_ALLOC_INST(ether, struct usbg_f_net, func)
 
-GENERIC_FREE_INST(ether, struct usbg_f_net, func);
+GENERIC_FREE_INST(ether, struct usbg_f_net, func)
 
 static int ether_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/ffs.c
+++ b/src/function/ffs.c
@@ -23,9 +23,9 @@ struct usbg_f_fs {
 	struct usbg_function func;
 };
 
-GENERIC_ALLOC_INST(ffs, struct usbg_f_fs, func);
+GENERIC_ALLOC_INST(ffs, struct usbg_f_fs, func)
 
-GENERIC_FREE_INST(ffs, struct usbg_f_fs, func);
+GENERIC_FREE_INST(ffs, struct usbg_f_fs, func)
 
 static int ffs_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/hid.c
+++ b/src/function/hid.c
@@ -198,9 +198,9 @@ struct {
 #undef HID_DEV_ATTR_RO
 #undef HID_RD_ATTR
 
-GENERIC_ALLOC_INST(hid, struct usbg_f_hid, func);
+GENERIC_ALLOC_INST(hid, struct usbg_f_hid, func)
 
-GENERIC_FREE_INST(hid, struct usbg_f_hid, func);
+GENERIC_FREE_INST(hid, struct usbg_f_hid, func)
 
 static int hid_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/loopback.c
+++ b/src/function/loopback.c
@@ -33,9 +33,9 @@ static size_t loopback_offsets[USBG_F_LOOPBACK_ATTR_MAX] = {
 	[USBG_F_LOOPBACK_QLEN] = offsetof(struct usbg_f_loopback_attrs, qlen),
 };
 
-GENERIC_ALLOC_INST(loopback, struct usbg_f_loopback, func);
+GENERIC_ALLOC_INST(loopback, struct usbg_f_loopback, func)
 
-GENERIC_FREE_INST(loopback, struct usbg_f_loopback, func);
+GENERIC_FREE_INST(loopback, struct usbg_f_loopback, func)
 
 static int loopback_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/midi.c
+++ b/src/function/midi.c
@@ -62,9 +62,9 @@ struct {
 #undef MIDI_DEC_ATTR
 #undef MIDI_STRING_ATTR
 
-GENERIC_ALLOC_INST(midi, struct usbg_f_midi, func);
+GENERIC_ALLOC_INST(midi, struct usbg_f_midi, func)
 
-GENERIC_FREE_INST(midi, struct usbg_f_midi, func);
+GENERIC_FREE_INST(midi, struct usbg_f_midi, func)
 
 static int midi_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/ms.c
+++ b/src/function/ms.c
@@ -148,7 +148,8 @@ static inline bool *get_lun_mask(struct usbg_f_ms *ms)
 	return ms->luns;
 }
 
-GENERIC_ALLOC_INST(ms_internal, struct usbg_f_ms, func);
+GENERIC_ALLOC_INST(ms_internal, struct usbg_f_ms, func)
+
 static int ms_alloc_inst(struct usbg_function_type *type,
 			 usbg_function_type type_code,
 			 const char *instance, const char *path,
@@ -170,7 +171,7 @@ out:
 	return ret;
 }
 
-GENERIC_FREE_INST(ms, struct usbg_f_ms, func);
+GENERIC_FREE_INST(ms, struct usbg_f_ms, func)
 
 static int ms_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/phonet.c
+++ b/src/function/phonet.c
@@ -23,9 +23,9 @@ struct usbg_f_phonet {
 	struct usbg_function func;
 };
 
-GENERIC_ALLOC_INST(phonet, struct usbg_f_phonet, func);
+GENERIC_ALLOC_INST(phonet, struct usbg_f_phonet, func)
 
-GENERIC_FREE_INST(phonet, struct usbg_f_phonet, func);
+GENERIC_FREE_INST(phonet, struct usbg_f_phonet, func)
 
 static int phonet_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/printer.c
+++ b/src/function/printer.c
@@ -21,9 +21,9 @@ struct usbg_f_printer {
 	struct usbg_function func;
 };
 
-GENERIC_ALLOC_INST(printer, struct usbg_f_printer, func);
+GENERIC_ALLOC_INST(printer, struct usbg_f_printer, func)
 
-GENERIC_FREE_INST(printer, struct usbg_f_printer, func);
+GENERIC_FREE_INST(printer, struct usbg_f_printer, func)
 
 #define PRINTER_FUNCTION_OPTS			\
 	.alloc_inst = printer_alloc_inst,	\

--- a/src/function/serial.c
+++ b/src/function/serial.c
@@ -22,9 +22,9 @@ struct usbg_f_serial {
 	struct usbg_function func;
 };
 
-GENERIC_ALLOC_INST(serial, struct usbg_f_serial, func);
+GENERIC_ALLOC_INST(serial, struct usbg_f_serial, func)
 
-GENERIC_FREE_INST(serial, struct usbg_f_serial, func);
+GENERIC_FREE_INST(serial, struct usbg_f_serial, func)
 
 static int serial_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/uac2.c
+++ b/src/function/uac2.c
@@ -51,9 +51,9 @@ static struct {
 
 #undef UAC2_DEC_ATTR
 
-GENERIC_ALLOC_INST(uac2, struct usbg_f_uac2, func);
+GENERIC_ALLOC_INST(uac2, struct usbg_f_uac2, func)
 
-GENERIC_FREE_INST(uac2, struct usbg_f_uac2, func);
+GENERIC_FREE_INST(uac2, struct usbg_f_uac2, func)
 
 static int uac2_set_attrs(struct usbg_function *f, void *f_attrs)
 {

--- a/src/function/uvc.c
+++ b/src/function/uvc.c
@@ -244,7 +244,8 @@ static inline struct formats *get_formats_mask(struct usbg_f_uvc *uvc)
 	return uvc->formats;
 }
 
-GENERIC_ALLOC_INST(uvc_internal, struct usbg_f_uvc, func);
+GENERIC_ALLOC_INST(uvc_internal, struct usbg_f_uvc, func)
+
 static int uvc_alloc_inst(struct usbg_function_type *type,
 			 usbg_function_type type_code,
 			 const char *instance, const char *path,
@@ -269,7 +270,7 @@ out:
 	return ret;
 }
 
-GENERIC_FREE_INST(uvc, struct usbg_f_uvc, func);
+GENERIC_FREE_INST(uvc, struct usbg_f_uvc, func)
 
 static int uvc_set_attrs(struct usbg_function *f, void *f_attrs)
 {
@@ -283,7 +284,7 @@ static int uvc_get_attrs(struct usbg_function *f, void *f_attrs)
 
 static void uvc_cleanup_attrs(struct usbg_function *f, void *f_attrs)
 {
-	return usbg_f_uvc_cleanup_attrs(f_attrs);
+	usbg_f_uvc_cleanup_attrs(f_attrs);
 }
 
 int usbg_f_uvc_get_config_attr_val(usbg_f_uvc *uvcf, enum usbg_f_uvc_config_attr iattr,
@@ -745,7 +746,7 @@ static int uvc_import_format(struct usbg_f_uvc *uvcf, const char *format, bool *
 
 out:
 	return ret;
-};
+}
 
 static int uvc_import_config(struct usbg_f_uvc *uvcf, config_setting_t *root)
 {
@@ -871,7 +872,7 @@ static int uvc_export_config(struct usbg_f_uvc *uvcf, config_setting_t *root)
 
 out:
 	return ret;
-};
+}
 
 static int uvc_export_format_attrs(struct usbg_f_uvc *uvcf, const char *format,
 				  config_setting_t *root)
@@ -947,7 +948,7 @@ static int uvc_export_frames(struct usbg_f_uvc *uvcf, const char *format,
 
 out:
 	return ret;
-};
+}
 
 static int uvc_libconfig_export(struct usbg_function *f, config_setting_t *root)
 {
@@ -1153,7 +1154,7 @@ static int uvc_remove(struct usbg_function *f, int opts)
 		return USBG_ERROR_PATH_TOO_LONG;
 
 	return ret;
-};
+}
 
 struct usbg_function_type usbg_f_type_uvc = {
 	.name = "uvc",

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -79,7 +79,7 @@ struct usbg_function_type* function_types[] = {
 	[USBG_F_PRINTER] = &usbg_f_type_printer,
 };
 
-ARRAY_SIZE_SENTINEL(function_types, USBG_FUNCTION_TYPE_MAX);
+ARRAY_SIZE_SENTINEL(function_types, USBG_FUNCTION_TYPE_MAX)
 
 const char *gadget_attr_names[] =
 {
@@ -93,7 +93,7 @@ const char *gadget_attr_names[] =
 	"bcdDevice"
 };
 
-ARRAY_SIZE_SENTINEL(gadget_attr_names, USBG_GADGET_ATTR_MAX);
+ARRAY_SIZE_SENTINEL(gadget_attr_names, USBG_GADGET_ATTR_MAX)
 
 const char *gadget_str_names[] =
 {
@@ -102,7 +102,7 @@ const char *gadget_str_names[] =
 	"serialnumber",
 };
 
-ARRAY_SIZE_SENTINEL(gadget_str_names, USBG_GADGET_STR_MAX);
+ARRAY_SIZE_SENTINEL(gadget_str_names, USBG_GADGET_STR_MAX)
 
 const char *gadget_os_desc_names[] =
 {
@@ -111,7 +111,7 @@ const char *gadget_os_desc_names[] =
 	"qw_sign",
 };
 
-ARRAY_SIZE_SENTINEL(gadget_os_desc_names, USBG_GADGET_OS_DESC_MAX);
+ARRAY_SIZE_SENTINEL(gadget_os_desc_names, USBG_GADGET_OS_DESC_MAX)
 
 int usbg_lookup_function_type(const char *name)
 {


### PR DESCRIPTION
This PR fixes some of the compile warnings.
examples/gadget-hid.c was just a matter of some casting, examples/gadget-vid-pid-remove.c was a bug, most others were stray ';'.

Two important things:
* the test set complains about 69 failed tests *before* my changes and also 69 after

* I did not understand container_of and ARRAY_SIZE_SENTINEL

First container_of:

```c
#define container_of(ptr, type, field) ({                               \
                        const typeof(((type *)0)->field) *member = (ptr); \
                        (type *)( (char *)member - offsetof(type, field) ); \
                })
```

member is assigned the contents of 'ptr' with a typeof but in the line after that, member is casted to char * anyway?

ARRAY_SIZE_SENTINEL: what is it for? It is instantiated 4 times but never referenced. Also it has the 'unused' attribute. So why bother? I disabled (not removed) it for now as compiling it produces warnings about 0-sized arrays.
