### PR TITLE
Add inquiry_string to LUN attributes

### DIFF
--- a/examples/gadget-ms.c
+++ b/examples/gadget-ms.c
@@ -65,6 +65,7 @@ int main(int argc, char **argv)
 			.nofua = 0,
 			.removable = 1,
 			.file = "",
+			.inquiry_string = "Empty"
 		}, {
 			.id = -1, /* allows to place in any position */
 			.cdrom = 0,
@@ -72,6 +73,7 @@ int main(int argc, char **argv)
 			.nofua = 0,
 			.removable = 1,
 			.file = argv[1],
+			.inquiry_string = "Non-empty"
 		}
 	};
 

--- a/examples/show-gadgets.c
+++ b/examples/show-gadgets.c
@@ -198,6 +198,7 @@ void show_function(usbg_function *f)
 			fprintf(stdout, "      nofua\t\t%d\n", attrs->luns[i]->nofua);
 			fprintf(stdout, "      removable\t\t%d\n", attrs->luns[i]->removable);
 			fprintf(stdout, "      file\t\t%s\n", attrs->luns[i]->file);
+			fprintf(stdout, "      inquiry_string\t\t%s\n", attrs->luns[i]->inquiry_string);
 		}
 		break;
 	}

--- a/include/usbg/function/ms.h
+++ b/include/usbg/function/ms.h
@@ -30,6 +30,7 @@ struct usbg_f_ms_lun_attrs {
 	bool nofua;
 	bool removable;
 	const char *file;
+	const char *inquiry_string;
 };
 
 struct usbg_f_ms_attrs {
@@ -45,6 +46,7 @@ enum usbg_f_ms_lun_attr {
 	USBG_F_MS_LUN_NOFUA,
 	USBG_F_MS_LUN_REMOVABLE,
 	USBG_F_MS_LUN_FILE,
+	USBG_F_MS_LUN_INQUIRY_STRING,
 	USBG_F_MS_LUN_ATTR_MAX
 };
 
@@ -54,6 +56,7 @@ union usbg_f_ms_lun_attr_val {
 	bool nofua;
 	bool removable;
 	const char *file;
+	const char *inquiry_string;
 };
 
 #define USBG_F_MS_LUN_BOOL_TO_ATTR_VAL(WHAT)		\
@@ -132,6 +135,8 @@ static inline void usbg_f_ms_cleanup_lun_attrs(struct usbg_f_ms_lun_attrs *lattr
 	if (lattrs) {
 		free((char *)lattrs->file);
 		lattrs->file = NULL;
+		free((char *)lattrs->inquiry_string);
+		lattrs->inquiry_string = NULL;
 	}
 }
 
@@ -315,6 +320,37 @@ static inline int usbg_f_ms_set_lun_file(usbg_f_ms *mf, int lun_id,
 {
 	return usbg_f_ms_set_lun_attr_val(mf, lun_id, USBG_F_MS_LUN_FILE,
 					  USBG_F_MS_LUN_CCHAR_PTR_TO_ATTR_VAL(file));
+}
+
+/**
+ * @brief Get the inquiry string of LUN which is used as name in SCSI inquiry
+ *         by this LUN into newly allocated storage
+ * @param[in] mf Pointer to ms function
+ * @param[in] lun_id ID of lun
+ * @param[out] inquiry_string Newly allocated string name of LUN used in SCSI
+ *         inquiry
+ * @return 0 on success usbg_error if error occurred.
+ * @note returned inquiry_string should be free() by caller
+ */
+static inline int usbg_f_ms_get_lun_inquiry_string(usbg_f_ms *mf, int lun_id,
+			       char **inquiry_string)
+{
+	return usbg_f_ms_get_lun_attr_val(mf, lun_id, USBG_F_MS_LUN_INQUIRY_STRING,
+					  (union usbg_f_ms_lun_attr_val *)inquiry_string);
+}
+
+/**
+ * @brief Set the inquiry string which is used as name in SCSI inquiry by this LUN
+ * @param[in] mf Pointer to ms function
+ * @param[in] lun_id ID of lun
+ * @param[in] inquiry_string Name of LUN which used in SCSI inquiry
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_ms_set_lun_inquiry_string(usbg_f_ms *mf, int lun_id,
+			   const char *inquiry_string)
+{
+	return usbg_f_ms_set_lun_attr_val(mf, lun_id, USBG_F_MS_LUN_INQUIRY_STRING,
+					  USBG_F_MS_LUN_CCHAR_PTR_TO_ATTR_VAL(inquiry_string));
 }
 
 /**

--- a/src/function/ms.c
+++ b/src/function/ms.c
@@ -64,6 +64,7 @@ static struct {
 	[USBG_F_MS_LUN_NOFUA] = MS_LUN_BOOL_ATTR(nofua),
 	[USBG_F_MS_LUN_REMOVABLE] = MS_LUN_BOOL_ATTR(removable),
 	[USBG_F_MS_LUN_FILE] = MS_LUN_STRING_ATTR(file),
+	[USBG_F_MS_LUN_INQUIRY_STRING] = MS_LUN_STRING_ATTR(inquiry_string),
 };
 
 static inline int lun_select(const struct dirent *dent)


### PR DESCRIPTION
# Add "inquiry_string" to LUN attributes
## What is inquiry_string in LUN attributes?
Inquiry string is a name of LUN which used in SCSI inquiry

### For example: 
#### Without inquiry_string (as now)
```
[timesnap] usb 1-9: new high-speed USB device number 22 using xhci_hcd
[timesnap] usb 1-9: New USB device found, idVendor=1d6b, idProduct=0104, bcdDevice= 0.01
[timesnap] usb 1-9: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[timesnap] usb 1-9: Product: Bar Gadget
[timesnap] usb 1-9: Manufacturer: Foo Inc.
[timesnap] usb 1-9: SerialNumber: 0123456789
[timesnap] usb-storage 1-9:1.0: USB Mass Storage device detected
[timesnap] scsi host6: usb-storage 1-9:1.0
[timesnap] scsi 6:0:0:0: Direct-Access     Linux    File-Stor Gadget 0607 PQ: 0 ANSI: 2
[timesnap] scsi 6:0:0:1: CD-ROM            Linux    File-Stor Gadget 0607 PQ: 0 ANSI: 2
```
#### Without inquiry_string (after merging this PR)
```
[timesnap] usb 1-9: new high-speed USB device number 23 using xhci_hcd
[timesnap] usb 1-9: New USB device found, idVendor=1d6b, idProduct=0104, bcdDevice= 0.01
[timesnap] usb 1-9: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[timesnap] usb 1-9: Product: Bar Gadget
[timesnap] usb 1-9: Manufacturer: Foo Inc.
[timesnap] usb 1-9: SerialNumber: 0123456789
[timesnap] usb-storage 1-9:1.0: USB Mass Storage device detected
[timesnap] scsi host6: usb-storage 1-9:1.0
[timesnap] scsi 6:0:0:0: Direct-Access     Non-empt y                     PQ: 0 ANSI: 2
[timesnap] scsi 6:0:0:1: CD-ROM            Empty                          PQ: 0 ANSI: 2
```

Solves: #86 