### PR TITLE
Feature to set bitrates and framebuffersize from configfs

### DIFF
--- a/src/function/uvc.c
+++ b/src/function/uvc.c
@@ -1049,7 +1049,7 @@ static int uvc_set_frame(char *format_path, const char *format, const struct usb
 	if (ret != USBG_SUCCESS)
 		return ret;
 
-	ret = usbg_write_dec(frame_path, frame_name, "dwMaxVideoFrameBufferSize", attrs->wHeight * attrs->wWidth);
+	ret = usbg_write_dec(frame_path, frame_name, "dwMaxVideoFrameBufferSize", attrs->dwMaxVideoFrameBufferSize);
 	if (ret != USBG_SUCCESS)
 		return ret;
 

--- a/src/function/uvc.c
+++ b/src/function/uvc.c
@@ -1049,7 +1049,19 @@ static int uvc_set_frame(char *format_path, const char *format, const struct usb
 	if (ret != USBG_SUCCESS)
 		return ret;
 
+	ret = usbg_write_dec(frame_path, frame_name, "dwDefaultFrameInterval", attrs->dwDefaultFrameInterval);
+	if (ret != USBG_SUCCESS)
+		return ret;
+
 	ret = usbg_write_dec(frame_path, frame_name, "dwMaxVideoFrameBufferSize", attrs->dwMaxVideoFrameBufferSize);
+	if (ret != USBG_SUCCESS)
+		return ret;
+
+	ret = usbg_write_dec(frame_path, frame_name, "dwMinBitRate", attrs->dwMinBitRate);
+	if (ret != USBG_SUCCESS)
+		return ret;
+
+	ret = usbg_write_dec(frame_path, frame_name, "dwMaxBitRate", attrs->dwMaxBitRate);
 	if (ret != USBG_SUCCESS)
 		return ret;
 


### PR DESCRIPTION
Pulled in the uvc patches from @any1 to write

- dwMaxVideoFrameBufferSize
- dwMinBitRate
- dwMaxBitRate

and fix setting of
- dwDefaultFrameInterval