### PR TITLE
Bugfix/functions buildwarnings

### DIFF
--- a/include/usbg/function/net.h
+++ b/include/usbg/function/net.h
@@ -50,7 +50,7 @@ union usbg_f_net_attr_val {
 	struct ether_addr dev_addr;
 	struct ether_addr host_addr;
 	const char *ifname;
-	int qmult;
+	unsigned int qmult;
 	unsigned int class_;
 	unsigned int subclass;
 	unsigned int protocol;
@@ -212,7 +212,7 @@ int usbg_f_net_get_ifname_s(usbg_f_net *nf, char *buf, int len);
  * @param[out] qmult Current multiplier of queue len
  * @return 0 on success usbg_error if error occurred.
  */
-static inline int usbg_f_net_get_qmult(usbg_f_net *nf, int *qmult)
+static inline int usbg_f_net_get_qmult(usbg_f_net *nf, unsigned int *qmult)
 {
 	return usbg_f_net_get_attr_val(nf, USBG_F_NET_QMULT,
 				       (union usbg_f_net_attr_val *)qmult);
@@ -224,7 +224,7 @@ static inline int usbg_f_net_get_qmult(usbg_f_net *nf, int *qmult)
  * @param[in] qmult Multiplier of queue len which should be set
  * @return 0 on success usbg_error if error occurred.
  */
-static inline int usbg_f_net_set_qmult(usbg_f_net *nf, int qmult)
+static inline int usbg_f_net_set_qmult(usbg_f_net *nf, unsigned int qmult)
 {
 	return usbg_f_net_set_attr_val(nf, USBG_F_NET_QMULT,
 				       USBG_F_NET_INT_TO_ATTR_VAL(qmult));

--- a/src/function/ms.c
+++ b/src/function/ms.c
@@ -166,7 +166,8 @@ static int ms_alloc_inst(struct usbg_function_type *type,
 		goto out;
 
 	mf = usbg_to_ms_function(*f);
-	memset(mf->luns, 0, sizeof(mf->luns));
+	for (int i = 0; i < MAX_LUNS; i++)
+		mf->luns[i] = 0;
 	mf->luns_initiated = false;
 out:
 	return ret;


### PR DESCRIPTION
When using meson we compile with all warnings being treated as errors.
To get the last build issue out of the way to make the meson merge work
I include these two fixes.