### PR TITLE
handle NCM and RNDIS differences

### DIFF
--- a/include/usbg/function/net.h
+++ b/include/usbg/function/net.h
@@ -27,30 +27,33 @@ typedef struct usbg_f_net usbg_f_net;
 struct usbg_f_net_attrs {
 	struct ether_addr dev_addr;
 	struct ether_addr host_addr;
-	const char *ifname;
 	int qmult;
-	unsigned int class_;
-	unsigned int subclass;
-	unsigned int protocol;
+	const char *ifname;
+	int max_segment_size;  /* NCM only */
+	unsigned int class_;   /* RNDIS only */
+	unsigned int subclass; /* RNDIS only */
+	unsigned int protocol; /* RNDIS only */
 };
 
 enum usbg_f_net_attr {
 	USBG_F_NET_ATTR_MIN = 0,
 	USBG_F_NET_DEV_ADDR = USBG_F_NET_ATTR_MIN,
 	USBG_F_NET_HOST_ADDR,
-	USBG_F_NET_IFNAME,
 	USBG_F_NET_QMULT,
-	USBG_F_NET_CLASS,
-	USBG_F_NET_SUBCLASS,
-	USBG_F_NET_PROTOCOL,
+	USBG_F_NET_IFNAME,
+	USBG_F_NET_MAX_SEGMENT_SIZE, /* NCM only */
+	USBG_F_NET_CLASS,            /* RNDIS only */
+	USBG_F_NET_SUBCLASS,         /* RNDIS only */
+	USBG_F_NET_PROTOCOL,         /* RNDIS only */
 	USBG_F_NET_ATTR_MAX
 };
 
 union usbg_f_net_attr_val {
 	struct ether_addr dev_addr;
 	struct ether_addr host_addr;
-	const char *ifname;
 	unsigned int qmult;
+	const char *ifname;
+	unsigned int max_segment_size;
 	unsigned int class_;
 	unsigned int subclass;
 	unsigned int protocol;
@@ -231,7 +234,31 @@ static inline int usbg_f_net_set_qmult(usbg_f_net *nf, unsigned int qmult)
 }
 
 /**
- * @brief Get the value of usb function class
+ * @brief Get the value of NCM max segment size
+ * @param[in] nf Pointer to net function
+ * @param[out] max_segment_size Current max segment size
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_get_max_segment_size(usbg_f_net *nf, unsigned int *max_segment_size)
+{
+	return usbg_f_net_get_attr_val(nf, USBG_F_NET_MAX_SEGMENT_SIZE,
+				       (union usbg_f_net_attr_val *)max_segment_size);
+}
+
+/**
+ * @brief Set the value of NCM max segment size
+ * @param[in] nf Pointer to net function
+ * @param[in] max_segment_size Max segment size to set
+ * @return 0 on success usbg_error if error occurred.
+ */
+static inline int usbg_f_net_set_max_segment_size(usbg_f_net *nf, unsigned int max_segment_size)
+{
+	union usbg_f_net_attr_val val = {.max_segment_size = max_segment_size};
+	return usbg_f_net_set_attr_val(nf, USBG_F_NET_MAX_SEGMENT_SIZE, &val);
+}
+
+/**
+ * @brief Get the value of RNDIS class
  * @param[in] nf Pointer to net function
  * @param[out] class_ Current class identification
  * @return 0 on success usbg_error if error occurred.
@@ -243,7 +270,7 @@ static inline int usbg_f_net_get_class(usbg_f_net *nf, unsigned int *class_)
 }
 
 /**
- * @brief Set the value of usb function class
+ * @brief Set the value of RNDIS class
  * @param[in] nf Pointer to net function
  * @param[in] class_ Class identification
  * @return 0 on success usbg_error if error occurred.
@@ -255,19 +282,19 @@ static inline int usbg_f_net_set_class(usbg_f_net *nf, unsigned int class_)
 }
 
 /**
- * @brief Get the value of usb function subclass
+ * @brief Get the value of RNDIS subclass
  * @param[in] nf Pointer to net function
  * @param[out] subclass Current subclass identification
  * @return 0 on success usbg_error if error occurred.
  */
-static inline int usbg_f_net_get_subclass(usbg_f_net *nf, int *subclass)
+static inline int usbg_f_net_get_subclass(usbg_f_net *nf, unsigned int *subclass)
 {
 	return usbg_f_net_get_attr_val(nf, USBG_F_NET_SUBCLASS,
 				       (union usbg_f_net_attr_val *)subclass);
 }
 
 /**
- * @brief Set the value of usb function subclass
+ * @brief Set the value of RNDIS subclass
  * @param[in] nf Pointer to net function
  * @param[in] subclass Subclass identification
  * @return 0 on success usbg_error if error occurred.
@@ -279,21 +306,21 @@ static inline int usbg_f_net_set_subclass(usbg_f_net *nf, unsigned int subclass)
 }
 
 /**
- * @brief Get the value of usb function protocol
+ * @brief Get the value of RNDIS protocol
  * @param[in] nf Pointer to net function
  * @param[out] protocol Current protocol identification
  * @return 0 on success usbg_error if error occurred.
  */
-static inline int usbg_f_net_get_protocol(usbg_f_net *nf, int *protocol)
+static inline int usbg_f_net_get_protocol(usbg_f_net *nf, unsigned int *protocol)
 {
 	return usbg_f_net_get_attr_val(nf, USBG_F_NET_PROTOCOL,
 				       (union usbg_f_net_attr_val *)protocol);
 }
 
 /**
- * @brief Set the value of usb function protocol
+ * @brief Set the value of RNDIS protocol
  * @param[in] nf Pointer to net function
- * @param[in] protocol protocol identification
+ * @param[in] protocol Protocol identification
  * @return 0 on success usbg_error if error occurred.
  */
 static inline int usbg_f_net_set_protocol(usbg_f_net *nf, unsigned int protocol)

--- a/src/function/ether.c
+++ b/src/function/ether.c
@@ -23,16 +23,20 @@ struct usbg_f_net {
 	struct usbg_function func;
 };
 
-#define NET_DEC_ATTR(_name)						\
+/* File name differs from C field name (_fname vs _cname) */
+#define NET_DEC_ATTR_NAMED(_fname, _cname)				\
 	{								\
-		.name = #_name,						\
+		.name = _fname,						\
 		.ro = false,					        \
-		.offset = offsetof(struct usbg_f_net_attrs, _name),     \
+		.offset = offsetof(struct usbg_f_net_attrs, _cname),    \
 		.get = usbg_get_dec,				        \
 		.set = usbg_set_dec,				        \
 		.import = usbg_get_config_node_int,	                \
 		.export = usbg_set_config_node_int,		        \
 	}
+
+/* File name matches the C field name */
+#define NET_DEC_ATTR(_name) NET_DEC_ATTR_NAMED(#_name, _name)
 
 #define NET_RO_STRING_ATTR(_name)					\
 	{								\
@@ -54,7 +58,7 @@ struct usbg_f_net {
 		.export = usbg_set_config_node_ether_addr,	        \
 	}
 
-static struct {
+static struct net_attr_entry {
 	const char *name;
 	bool ro;
 	size_t offset;
@@ -62,18 +66,39 @@ static struct {
 	usbg_attr_set_func set;
 	usbg_import_node_func import;
 	usbg_export_node_func export;
-} net_attr[USBG_F_NET_ATTR_MAX] = {
-	[USBG_F_NET_DEV_ADDR] = NET_ETHER_ADDR_ATTR(dev_addr),
+}
+net_attr_base[USBG_F_NET_ATTR_MAX] = {
+	[USBG_F_NET_DEV_ADDR]  = NET_ETHER_ADDR_ATTR(dev_addr),
 	[USBG_F_NET_HOST_ADDR] = NET_ETHER_ADDR_ATTR(host_addr),
-	[USBG_F_NET_IFNAME] = NET_RO_STRING_ATTR(ifname),
-	[USBG_F_NET_QMULT] = NET_DEC_ATTR(qmult),
-	[USBG_F_NET_CLASS] = NET_DEC_ATTR(class_),
-	[USBG_F_NET_SUBCLASS] = NET_DEC_ATTR(subclass),
-	[USBG_F_NET_PROTOCOL] = NET_DEC_ATTR(protocol)
+	[USBG_F_NET_QMULT]     = NET_DEC_ATTR(qmult),
+	[USBG_F_NET_IFNAME]    = NET_RO_STRING_ATTR(ifname),
+	/* MAX_SEGMENT_SIZE, CLASS, SUBCLASS, PROTOCOL: N/A — zero-initialized */
+},
+
+net_attr_ncm[USBG_F_NET_ATTR_MAX] = {
+	[USBG_F_NET_DEV_ADDR]          = NET_ETHER_ADDR_ATTR(dev_addr),
+	[USBG_F_NET_HOST_ADDR]         = NET_ETHER_ADDR_ATTR(host_addr),
+	[USBG_F_NET_QMULT]             = NET_DEC_ATTR(qmult),
+	[USBG_F_NET_IFNAME]            = NET_RO_STRING_ATTR(ifname),
+	[USBG_F_NET_MAX_SEGMENT_SIZE]  = NET_DEC_ATTR(max_segment_size),
+	/* CLASS, SUBCLASS, PROTOCOL: N/A — zero-initialized */
+},
+
+net_attr_rndis[USBG_F_NET_ATTR_MAX] = {
+	[USBG_F_NET_DEV_ADDR]  = NET_ETHER_ADDR_ATTR(dev_addr),
+	[USBG_F_NET_HOST_ADDR] = NET_ETHER_ADDR_ATTR(host_addr),
+	[USBG_F_NET_QMULT]     = NET_DEC_ATTR(qmult),
+	[USBG_F_NET_IFNAME]    = NET_RO_STRING_ATTR(ifname),
+	/* MAX_SEGMENT_SIZE: N/A — zero-initialized */
+	[USBG_F_NET_CLASS]     = NET_DEC_ATTR_NAMED("class", class_),
+	[USBG_F_NET_SUBCLASS]  = NET_DEC_ATTR(subclass),
+	[USBG_F_NET_PROTOCOL]  = NET_DEC_ATTR(protocol),
 };
 
 #undef NET_DEC_ATTR
-#undef NET_STRING_ATTR
+#undef NET_DEC_ATTR_NAMED
+#undef NET_RO_STRING_ATTR
+#undef NET_ETHER_ADDR_ATTR
 
 GENERIC_ALLOC_INST(ether, struct usbg_f_net, func)
 
@@ -102,21 +127,24 @@ static void ether_cleanup_attrs(struct usbg_function *f, void *f_attrs)
 	usbg_f_net_cleanup_attrs(f_attrs);
 }
 
+static struct net_attr_entry *ether_get_attr_table(usbg_f_net *nf);
+
 #ifdef HAS_GADGET_SCHEMES
 
 static int ether_libconfig_import(struct usbg_function *f,
 				  config_setting_t *root)
 {
 	struct usbg_f_net *nf = usbg_to_net_function(f);
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
 	union usbg_f_net_attr_val val;
 	int i;
 	int ret = 0;
 
 	for (i = USBG_F_NET_ATTR_MIN; i < USBG_F_NET_ATTR_MAX; ++i) {
-		if (net_attr[i].ro)
+		if (!tbl[i].name || tbl[i].ro)
 			continue;
 
-		ret = net_attr[i].import(root, net_attr[i].name, &val);
+		ret = tbl[i].import(root, tbl[i].name, &val);
 		/* node not  found */
 		if (ret == 0)
 			continue;
@@ -136,19 +164,20 @@ static int ether_libconfig_export(struct usbg_function *f,
 				  config_setting_t *root)
 {
 	struct usbg_f_net *nf = usbg_to_net_function(f);
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
 	union usbg_f_net_attr_val val;
 	int i;
 	int ret = 0;
 
 	for (i = USBG_F_NET_ATTR_MIN; i < USBG_F_NET_ATTR_MAX; ++i) {
-		if (net_attr[i].ro)
+		if (!tbl[i].name || tbl[i].ro)
 			continue;
 
 		ret = usbg_f_net_get_attr_val(nf, i, &val);
 		if (ret)
 			break;
 
-		ret = net_attr[i].export(root, net_attr[i].name, &val);
+		ret = tbl[i].export(root, tbl[i].name, &val);
 		if (ret)
 			break;
 	}
@@ -213,6 +242,15 @@ struct usbg_function_type usbg_f_type_rndis = {
 
 /* API implementation */
 
+static struct net_attr_entry *ether_get_attr_table(usbg_f_net *nf)
+{
+	if (nf->func.ops == &usbg_f_type_ncm)
+		return net_attr_ncm;
+	if (nf->func.ops == &usbg_f_type_rndis)
+		return net_attr_rndis;
+	return net_attr_base;
+}
+
 usbg_f_net *usbg_to_net_function(usbg_function *f)
 {
 	return f->ops == &usbg_f_type_ecm
@@ -231,14 +269,17 @@ usbg_function *usbg_from_net_function(usbg_f_net *nf)
 int usbg_f_net_get_attrs(usbg_f_net *nf,
 			  struct usbg_f_net_attrs *attrs)
 {
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
 	int i;
 	int ret = 0;
 
 	for (i = USBG_F_NET_ATTR_MIN; i < USBG_F_NET_ATTR_MAX; ++i) {
+		if (!tbl[i].name)
+			continue;
 		ret = usbg_f_net_get_attr_val(nf, i,
 					       (union usbg_f_net_attr_val *)
 					       ((char *)attrs
-						+ net_attr[i].offset));
+						+ tbl[i].offset));
 		if (ret)
 			break;
 	}
@@ -250,17 +291,18 @@ int usbg_f_net_get_attrs(usbg_f_net *nf,
 int usbg_f_net_set_attrs(usbg_f_net *nf,
 			 const struct usbg_f_net_attrs *attrs)
 {
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
 	int i;
 	int ret = 0;
 
 	for (i = USBG_F_NET_ATTR_MIN; i < USBG_F_NET_ATTR_MAX; ++i) {
-		if (net_attr[i].ro)
+		if (!tbl[i].name || tbl[i].ro)
 			continue;
 
 		ret = usbg_f_net_set_attr_val(nf, i,
 					       *(union usbg_f_net_attr_val *)
 					       ((char *)attrs
-						+ net_attr[i].offset));
+						+ tbl[i].offset));
 		if (ret)
 			break;
 	}
@@ -272,17 +314,29 @@ int usbg_f_net_set_attrs(usbg_f_net *nf,
 int usbg_f_net_get_attr_val(usbg_f_net *nf, enum usbg_f_net_attr attr,
 			    union usbg_f_net_attr_val *val)
 {
-	return net_attr[attr].get(nf->func.path, nf->func.name,
-				    net_attr[attr].name, val);
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
+
+	if (attr < USBG_F_NET_ATTR_MIN || attr >= USBG_F_NET_ATTR_MAX)
+		return USBG_ERROR_INVALID_PARAM;
+	if (!tbl[attr].name)
+		return USBG_ERROR_NOT_FOUND;
+
+	return tbl[attr].get(nf->func.path, nf->func.name, tbl[attr].name, val);
 }
 
 int usbg_f_net_set_attr_val(usbg_f_net *nf, enum usbg_f_net_attr attr,
 			    union usbg_f_net_attr_val val)
 {
-	return net_attr[attr].ro ?
-		USBG_ERROR_INVALID_PARAM :
-		net_attr[attr].set(nf->func.path, nf->func.name,
-				   net_attr[attr].name, &val);
+	struct net_attr_entry *tbl = ether_get_attr_table(nf);
+
+	if (attr < USBG_F_NET_ATTR_MIN || attr >= USBG_F_NET_ATTR_MAX)
+		return USBG_ERROR_INVALID_PARAM;
+	if (!tbl[attr].name)
+		return USBG_ERROR_NOT_FOUND;
+	if (tbl[attr].ro)
+		return USBG_ERROR_INVALID_PARAM;
+
+	return tbl[attr].set(nf->func.path, nf->func.name, tbl[attr].name, val);
 }
 
 int usbg_f_net_get_ifname_s(usbg_f_net *nf, char *buf, int len)


### PR DESCRIPTION
cdc-ncm and rndis have some commonalities and differences. To support save&restore of either the type needs to be detected and acted accordingly.

This PR would refactor some data structures and functions to cover both.

The cdc-ncm part was tested and works fine on our devices - but the rndis could use a second pair of eyes and testers :-)

The implementation goes into the direction mentioned here: https://github.com/linux-usb-gadgets/libusbgx/issues/102#issuecomment-2547924903
and might solve #102 and #101